### PR TITLE
main.py added endpoint to send translations words from en to ua. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ TRANSLATOR_URL="http://translator:3002"
 .gitignore
 .venv
 .idea
+translator/data
 
 4) Run docker-compose up --build. When using IDE you should sometimes include docker-compose.override.yml file manually to run the project in the IDE.
 5) Open http://localhost:3001 in your browser

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,3 +8,7 @@ services:
   database:
     ports:
       - "5432:5432"
+
+  translator:
+    ports:
+      - "3002:3002"

--- a/translator/Dockerfile
+++ b/translator/Dockerfile
@@ -11,6 +11,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application code.
 COPY main.py main.py
+COPY data/production data/production
 
 # Expose the port that the app runs on.
 EXPOSE 3000

--- a/translator/main.py
+++ b/translator/main.py
@@ -1,3 +1,5 @@
+import json
+
 from fastapi import FastAPI
 import uvicorn
 
@@ -6,6 +8,10 @@ app = FastAPI()
 @app.get("/")
 async def read_root():
     return {"Hello": "World"}
+
+@app.get("/en-to-ua-words")
+async def to_ua_words():
+    return json.loads(open("data/production/en_to_ua_words.json").read())
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=3002)


### PR DESCRIPTION
This pull request includes changes to add a new `translator` service to the project. The most important changes involve updating configuration files, adding new data files, and modifying the `translator` service code.

Configuration updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17): Added `translator/data` to the list of files.
* [`docker-compose.override.yml`](diffhunk://#diff-2286cdeca85adb587a9640aa34352ba7c2fb6e49c0129dab05892ff67d0d4c58R11-R14): Added a new `translator` service with port mapping `3002:3002`.

Data and code updates:

* [`translator/Dockerfile`](diffhunk://#diff-94ecbf9838797f825f2dc11bcb9e930b469b56261fe44b1f6859e2804941232dR14): Added a line to copy the `data/production` directory into the Docker image.
* [`translator/main.py`](diffhunk://#diff-93208c68387ab36e3d212e72929ad2d0c9719446714eb88f6465b897c4c1d2dbR1-R2): Imported the `json` module and added a new endpoint `/en-to-ua-words` to read and return data from `en_to_ua_words.json`. [[1]](diffhunk://#diff-93208c68387ab36e3d212e72929ad2d0c9719446714eb88f6465b897c4c1d2dbR1-R2) [[2]](diffhunk://#diff-93208c68387ab36e3d212e72929ad2d0c9719446714eb88f6465b897c4c1d2dbR12-R15)