### PR TITLE
Add email confirmation check in session validation logic

### DIFF
--- a/backend/endpoints/user/tools.py
+++ b/backend/endpoints/user/tools.py
@@ -55,5 +55,7 @@ def validate_session(access_token: str = Header(...,
         raise HTTPException(status_code=404, detail="User not found")
     if user.is_banned:
         raise HTTPException(status_code=403, detail="User is banned")
+    if not user.is_confirmed:
+        raise HTTPException(status_code=403, detail="Email is not confirmed")
 
     return user


### PR DESCRIPTION
This pull request includes changes to the `validate_session` function to add a check for email confirmation and updates to the corresponding unit tests to cover this new functionality.

Changes to `validate_session` function:

* Added a check to raise an HTTP 403 exception if the user's email is not confirmed in `validate_session` function in `backend/endpoints/user/tools.py`.

Updates to unit tests:

* Modified the `test_validate_session_success` test to include the `is_confirmed` attribute in the mock user object in `backend/unit_tests/endpoints/user/test_tools.py`.
* Added a new test `test_validate_session_email_not_confirmed` to verify that an HTTP 403 exception is raised when the user's email is not confirmed in `backend/unit_tests/endpoints/user/test_tools.py`.