### PR TITLE
Add logout endpoint and corresponding tests for successful logout

### DIFF
--- a/backend/endpoints/user/login.py
+++ b/backend/endpoints/user/login.py
@@ -65,3 +65,12 @@ async def login_user(user: User = Depends(validate_session)):
     '''
     return {"message": f"Hello {user.name}!"}
 
+@router.get("/logout", response_model=MessageResponse)
+async def logout(request: Request):
+    '''
+    This endpoint validates is the user is logged in
+    '''
+    response = JSONResponse(content={"message": "Logout successful"})
+    for cookie in request.cookies:
+        response.delete_cookie(key=cookie)
+    return response

--- a/backend/unit_tests/endpoints/user/test_login.py
+++ b/backend/unit_tests/endpoints/user/test_login.py
@@ -118,3 +118,24 @@ class TestValidateSession:
         })
 
         assert response.status_code == 401
+
+
+class TestLogout:
+
+    @pytest.fixture
+    def client(self):
+        return TestClient(app)
+
+    def test_logout_success(self, client):
+        response = client.get("/user/logout", cookies={
+            "session-token": "valid_token"
+        })
+        assert response.status_code == 200
+        assert response.json() == {"message": "Logout successful"}
+        assert "session-token" not in response.cookies
+
+    def test_logout_no_cookies(self, client):
+        response = client.get("/user/logout")
+        assert response.status_code == 200
+        assert response.json() == {"message": "Logout successful"}
+        assert "session-token" not in response.cookies


### PR DESCRIPTION
This pull request introduces a new logout endpoint and corresponding unit tests to the user login functionality. The most important changes include adding the logout endpoint and creating test cases to ensure its correct behavior.

New endpoint addition:

* [`backend/endpoints/user/login.py`](diffhunk://#diff-0226b7231b4d9f799e21099d8b352cb00f49bdf16f7e912a316254e3525ec365R68-R76): Added a new `logout` endpoint that clears all cookies from the request and returns a success message.

Unit tests for the new endpoint:

* [`backend/unit_tests/endpoints/user/test_login.py`](diffhunk://#diff-9e25a7f8392c953f444fee8e4f3df6c9d957b3fc81dc9f9b5b42cec26cdb0f72R121-R141): Added a new `TestLogout` class with test cases to verify successful logout and logout with no cookies.

Closes #27 