### PR TITLE
Normalize email

### DIFF
--- a/backend/endpoints/user/login.py
+++ b/backend/endpoints/user/login.py
@@ -29,14 +29,15 @@ async def login_user(user: UserLogin, db: Session = Depends(get_db)):
     This function logs in a user, if login is successful, it saves access token in http only cookies.
     After 200 response frontend can access protected endpoints without any additional actions.
     '''
-    existing_user: User | None = db.query(User).filter(User.email == user.email).first()
+    email = str(user.email).lower()
+    existing_user: User | None = db.query(User).filter(User.email == email).first()
     if existing_user is None:
         raise HTTPException(status_code=400, detail="Invalid email or password")
 
     if not verify_password(user.password, existing_user.password_hash):
         raise HTTPException(status_code=400, detail="Invalid email or password")
 
-    token = generate_token(str(user.email), os.getenv("SECRET_KEY"),
+    token = generate_token(email, os.getenv("SECRET_KEY"),
                            expiration_date=datetime.now(timezone.utc) + timedelta(days=30))
 
     new_session = UserSession(

--- a/backend/endpoints/user/register.py
+++ b/backend/endpoints/user/register.py
@@ -37,7 +37,7 @@ async def register_user(user: UserCreate, db: Session = Depends(get_db)):
     hashed_password = hash_password(user.password)
 
     new_user = User(
-        email=str(user.email),
+        email=str(user.email).lower(),
         password_hash=hashed_password,
         name=user.name,
         surname=user.surname

--- a/backend/unit_tests/endpoints/user/test_login.py
+++ b/backend/unit_tests/endpoints/user/test_login.py
@@ -55,6 +55,28 @@ class TestLoginUser:
         assert session.is_active is True
         assert session.token == token
 
+
+    def test_login_user_success_email_uppercase(self, client):
+
+        response = client.post("/user/login", json={
+            "email": "Test@example.com",
+            "password": "password",
+        })
+
+        assert response.status_code == 200
+        cookies = response.headers.get("set-cookie")
+        token = None
+        for cookie in cookies.split(';'):
+            if cookie.strip().startswith("session-token="):
+                token = cookie.split('=')[1]
+                break
+        assert token is not None
+        db = next(get_db())
+        user = db.query(User).filter(User.email == "test@example.com").first()
+        session = db.query(Session).filter(Session.user_id == user.id).first()
+        assert session.is_active is True
+        assert session.token == token
+
     def test_login_wrong_email(self):
         response = client.post("/user/login", json={
             "email": "wrong@email.com",


### PR DESCRIPTION
This pull request includes changes to ensure that email addresses are handled in a case-insensitive manner during user login and registration processes. Additionally, new unit tests have been added to verify the functionality of these changes.

Changes to email handling:

* [`backend/endpoints/user/login.py`](diffhunk://#diff-0226b7231b4d9f799e21099d8b352cb00f49bdf16f7e912a316254e3525ec365L32-R40): Converted the user's email to lowercase before querying the database and generating the token.
* [`backend/endpoints/user/register.py`](diffhunk://#diff-bda3eee547a3d246345c11e1f0379d78494b93870a2c58096d22b66505e44b2bL40-R40): Converted the user's email to lowercase before creating a new user in the database.

New unit tests:

* [`backend/unit_tests/endpoints/user/test_login.py`](diffhunk://#diff-9e25a7f8392c953f444fee8e4f3df6c9d957b3fc81dc9f9b5b42cec26cdb0f72R58-R79): Added a new test to verify that the login process works correctly with an email address containing uppercase letters.
* [`backend/unit_tests/endpoints/user/test_register.py`](diffhunk://#diff-52725c79f0bc7d78f9f8f66e463fc8f2268052a5c0707f7eedea187bbb453fe8R50-R68): Added a new test to verify that the registration process works correctly with an email address containing uppercase letters.

closes #45 