### PR TITLE
add admin session validation endpoint

### DIFF
--- a/backend/endpoints/admin/__init__.py
+++ b/backend/endpoints/admin/__init__.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter
 from . import data_migration
+from . import session
 
 router = APIRouter()
 router.include_router(data_migration.router)
+router.include_router(session.router)

--- a/backend/endpoints/admin/session.py
+++ b/backend/endpoints/admin/session.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+
+from database.models import User
+from .tools import validate_admin_session
+from ..tools import ErrorResponse, MessageResponse
+
+router = APIRouter()
+
+@router.get("/validate-session", response_model=MessageResponse, responses={
+    401: {"model": ErrorResponse, "description": "Unauthorized"},
+    403: {"model": ErrorResponse, "description": "Forbidden"},
+    404: {"model": ErrorResponse, "description": "Not Found (user was deleted)"}
+})
+async def login_user(user: User = Depends(validate_admin_session)):
+    '''
+    This endpoint validates is the user is logged in
+    '''
+    return {"message": f"Hello {user.name}!"}

--- a/backend/unit_tests/endpoints/admin/test_session.py
+++ b/backend/unit_tests/endpoints/admin/test_session.py
@@ -1,0 +1,64 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from database import get_db
+from database.models import User
+from main import app
+from endpoints.user.hashing import hash_password
+from unit_tests.tools import clear_database
+
+
+class TestValidateSession:
+
+    @pytest.fixture
+    def client(self):
+        app.dependency_overrides.clear()
+        return TestClient(app)
+
+    def setup_class(self):
+        client = TestClient(app)
+        clear_database()
+        db = next(get_db())
+        db.add(User(email="admin@example.com", name="Test", surname="User",
+                    password_hash=hash_password("password"),
+                    is_confirmed=True, is_admin=True))
+        db.commit()
+        response = client.post("/user/login", json={
+            "email": "admin@example.com",
+            "password": "password",
+        })
+        cookies = response.headers.get("set-cookie")
+        assert "session-token=" in cookies
+        token = cookies.split("session-token=")[1].split(';')[0]
+        self.valid_token = token
+
+
+    def test_validate_admin_success(self, client):
+        response = client.get("/admin/validate-session", cookies={
+            "session-token": self.valid_token
+        })
+
+        assert response.status_code == 200
+        assert response.json().get("message", None) == "Hello Test!"
+
+    def test_validate_admin_fail(self, client):
+        response = client.get("/admin/validate-session", cookies={
+            "session-token": "invalid token"
+        })
+
+        assert response.status_code == 401
+
+    def test_not_admin(self, client):
+        db = next(get_db())
+        user = db.query(User).filter(User.email == "admin@example.com").first()
+        user.is_admin = False
+        db.commit()
+        response = client.get("/admin/validate-session", cookies={
+            "session-token": self.valid_token
+        })
+        user.is_admin = True
+        db.commit()
+
+        assert response.status_code == 403
+        assert response.json().get("detail", None) == "Access denied"
+


### PR DESCRIPTION
This pull request introduces a new session validation endpoint for admin users and includes corresponding tests. The main changes involve adding a new route and implementing tests to ensure the functionality works as expected.

New endpoint implementation:

* [`backend/endpoints/admin/__init__.py`](diffhunk://#diff-a1e6057bcdc0fece70346c5395eb81ed476fb0ce184d084ffc1ba41bc37ae146R3-R7): Included the new session router in the admin routes.
* [`backend/endpoints/admin/session.py`](diffhunk://#diff-db48c507d83b7a2fd8bbf30b32fc9a96c47d9f6ed2f1fdd483e8c12b511b648fR1-R18): Added a new endpoint `/validate-session` to validate if the user is logged in as an admin.

Unit tests for the new endpoint:

* [`backend/unit_tests/endpoints/admin/test_session.py`](diffhunk://#diff-e81391e7c740d66f879c626d2551c74f1777264fad7b5578529edc660d471b84R1-R64): Implemented tests for the new `/validate-session` endpoint, including scenarios for successful validation, invalid token, and non-admin user.

closes #42 