### PR TITLE
Update migration endpoints to sync English to Ukrainian words from CSV

### DIFF
--- a/backend/endpoints/admin/data_migration.py
+++ b/backend/endpoints/admin/data_migration.py
@@ -25,7 +25,7 @@ def words_translations_to_pairs(data: dict) -> list:
 @router.post("/migrate-words", response_model=MessageResponse)
 async def migrate_words(user: User = Depends(validate_admin_session),
                               db: Session = Depends(get_db)):
-    url = os.getenv("TRANSLATOR_URL") + "/en-to-ua-words"
+    url = os.getenv("TRANSLATOR_URL") + "/sync-en-ua-words"
     async with httpx.AsyncClient() as client:
         response = await client.get(url)
         response.raise_for_status()

--- a/translator/main.py
+++ b/translator/main.py
@@ -1,4 +1,5 @@
 import json
+import csv
 
 from fastapi import FastAPI
 import uvicorn
@@ -9,9 +10,22 @@ app = FastAPI()
 async def read_root():
     return {"Hello": "World"}
 
-@app.get("/en-to-ua-words")
-async def to_ua_words():
-    return json.loads(open("data/production/en_to_ua_words.json").read())
+@app.get("/sync-en-ua-words")
+async def sync_en_ua_words():
+    csv_file_path = "data/production/uatoeng.csv"
+    words = {}
+    res = {}
+    with open(csv_file_path, mode='r', encoding='utf-8') as csvfile:
+        reader = csv.reader(csvfile)
+        for row in reader:
+            ua_word = row[0]
+            en_words = row[1]
+            for en_word in en_words.split(' / '):
+                if res.get(en_word, None) is None:
+                    res[en_word] = []
+                res[en_word].append(ua_word)
+
+    return res
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=3002)


### PR DESCRIPTION
This pull request includes changes to the `backend/endpoints/admin/data_migration.py` and `translator/main.py` files to update the word translation synchronization process. The most important changes include modifying the endpoint URL for the translation sync and updating the translation logic to read from a CSV file instead of a JSON file.

Changes to the translation synchronization process:

* [`backend/endpoints/admin/data_migration.py`](diffhunk://#diff-eb5d223dc17058812d80163849edd87c3560c4f7eb24561469547f7a18974a86L28-R28): Updated the endpoint URL for the translation synchronization from `"/en-to-ua-words"` to `"/sync-en-ua-words"`.

* [`translator/main.py`](diffhunk://#diff-93208c68387ab36e3d212e72929ad2d0c9719446714eb88f6465b897c4c1d2dbR2): Imported the `csv` module to handle CSV file operations.

* [`translator/main.py`](diffhunk://#diff-93208c68387ab36e3d212e72929ad2d0c9719446714eb88f6465b897c4c1d2dbL12-R28): Replaced the `to_ua_words` endpoint with `sync_en_ua_words`, which reads translations from a CSV file (`data/production/uatoeng.csv`) and processes them into a dictionary format.

closes #53 