### PR TITLE
Add account management with password change functionality and tests

### DIFF
--- a/backend/endpoints/user/__init__.py
+++ b/backend/endpoints/user/__init__.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
 from . import register
-from . import login
+from . import login, account
 
 
 router = APIRouter()
 router.include_router(register.router)
 router.include_router(login.router)
+router.include_router(account.router)

--- a/backend/endpoints/user/account.py
+++ b/backend/endpoints/user/account.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from database import get_db, DatabaseSession
+from endpoints.tools import MessageResponse, ErrorResponse
+from .hashing import verify_password, hash_password
+from database.models import User
+from .tools import validate_session, is_strong_password
+
+router = APIRouter()
+
+class PasswordChangeRequest(BaseModel):
+    old_password: str
+    new_password: str
+
+@router.post("/change-password", response_model=MessageResponse, responses={
+    400: {"model": ErrorResponse, "description": "Bad Request (Invalid new password, Invalid old password)"},
+})
+async def password_change(data: PasswordChangeRequest, user: User = Depends(validate_session),
+                          db: DatabaseSession = Depends(get_db)):
+    '''
+    This endpoint changes user password.
+    '''
+    if not verify_password(data.old_password, user.password_hash):
+        raise HTTPException(status_code=400, detail="Invalid old password")
+
+    if not is_strong_password(data.new_password):
+        raise HTTPException(status_code=400, detail="New password is not strong enough")
+    hashed_password = hash_password(data.new_password)
+    user.password_hash = hashed_password
+    db.commit()
+    return MessageResponse(message="Password changed successfully")

--- a/backend/unit_tests/endpoints/user/test_account.py
+++ b/backend/unit_tests/endpoints/user/test_account.py
@@ -1,0 +1,68 @@
+import os
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from database import get_db, engine, DatabaseSession
+from database.models import Base, User, Session
+from endpoints.user.tools import generate_token
+from main import app
+from endpoints.user.hashing import hash_password, verify_password
+from unit_tests.tools import clear_database
+
+client = TestClient(app)
+
+class TestChangePassword:
+
+    @pytest.fixture
+    def client(self):
+        return TestClient(app)
+
+    def setup_method(self, client):
+        clear_database()
+        db = next(get_db())
+        self.user = User(email="test@example.com", name="Test", surname="User",
+                    password_hash=hash_password("password"),
+                    is_confirmed=True)
+        db.add(self.user)
+        db.commit()
+        token = generate_token("test@example.com", os.getenv("SECRET_KEY"),
+                               expiration_date=datetime.now(timezone.utc) + timedelta(days=30))
+        self.session = Session(user_id=self.user.id, token=token)
+        db.add(self.session)
+        db.commit()
+        db.refresh(self.session)
+        db.refresh(self.user)
+        db.expunge(self.session)
+        db.expunge(self.user)
+
+
+    def test_ok(self, client):
+
+        response = client.post("/user/change-password", json={
+            "old_password": "password",
+            "new_password": "new-passwordA1!",
+        },
+                               cookies={"session-token": self.session.token})
+        assert response.status_code == 200
+        db = next(get_db())
+        user = db.query(User).filter(User.id == self.user.id).first()
+        assert not verify_password("password", user.password_hash)
+        assert verify_password("new-passwordA1!", user.password_hash)
+
+    def test_wrong_old_password(self, client):
+        response = client.post("/user/change-password", json={
+            "old_password": "wrong-password",
+            "new_password": "new-passwordA1!",
+        }, cookies={"session-token": self.session.token})
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Invalid old password"}
+
+    def test_wrong_new_password(self, client):
+        response = client.post("/user/change-password", json={
+            "old_password": "password",
+            "new_password": "weak",
+        }, cookies={"session-token": self.session.token})
+        assert response.status_code == 400
+        assert response.json() == {"detail": "New password is not strong enough"}


### PR DESCRIPTION
This pull request introduces a new endpoint for changing user passwords and includes corresponding unit tests. The most important changes are the addition of the `account` module, the implementation of the password change endpoint, and the creation of unit tests for this functionality.

### New Endpoint for Changing User Passwords:

* [`backend/endpoints/user/__init__.py`](diffhunk://#diff-cd03f3869ed6caa09c2d90b094a5bbdd4dc8f2c300bbcb486b260293f06b20f0L3-R9): Included the `account` module in the user endpoints.
* [`backend/endpoints/user/account.py`](diffhunk://#diff-d21179ae061b1497805a28582ba288f2b55f6734329338c96dfb1ee182fee0bcR1-R32): Added a new endpoint `/change-password` that allows users to change their passwords after validating their old password and ensuring the new password meets strength requirements.

### Unit Tests for Password Change Endpoint:

* [`backend/unit_tests/endpoints/user/test_account.py`](diffhunk://#diff-a365bcac8188155330eba0d808fe1a9bb3f24d44683640bb6ef4c37ca004d090R1-R68): Created unit tests for the password change endpoint, including tests for successful password change, incorrect old password, and weak new password.

closes #49 