### PR TITLE
Add password change validation to prevent reuse of old password

### DIFF
--- a/backend/endpoints/user/account.py
+++ b/backend/endpoints/user/account.py
@@ -26,6 +26,9 @@ async def password_change(data: PasswordChangeRequest, user: User = Depends(vali
 
     if not is_strong_password(data.new_password):
         raise HTTPException(status_code=400, detail="New password is not strong enough")
+
+    if verify_password(data.new_password, user.password_hash):
+        raise HTTPException(status_code=400, detail="New password cannot be the same as the old password")
     hashed_password = hash_password(data.new_password)
     user.password_hash = hashed_password
     db.commit()


### PR DESCRIPTION
This pull request includes updates to the password change functionality and corresponding unit tests in the `backend/endpoints/user/account.py` and `backend/unit_tests/endpoints/user/test_account.py` files. The most important changes are the addition of a check to prevent users from setting their new password to the same as their old password and updates to the unit tests to reflect this new check.

Improvements to password change functionality:

* [`backend/endpoints/user/account.py`](diffhunk://#diff-d21179ae061b1497805a28582ba288f2b55f6734329338c96dfb1ee182fee0bcR29-R31): Added a check to ensure the new password is not the same as the old password.

Updates to unit tests:

* [`backend/unit_tests/endpoints/user/test_account.py`](diffhunk://#diff-a365bcac8188155330eba0d808fe1a9bb3f24d44683640bb6ef4c37ca004d090L26-R26): Updated the `setup_method` to use a stronger initial password.
* [`backend/unit_tests/endpoints/user/test_account.py`](diffhunk://#diff-a365bcac8188155330eba0d808fe1a9bb3f24d44683640bb6ef4c37ca004d090L44-R51): Updated the `test_ok` method to reflect the stronger initial password.
* [`backend/unit_tests/endpoints/user/test_account.py`](diffhunk://#diff-a365bcac8188155330eba0d808fe1a9bb3f24d44683640bb6ef4c37ca004d090L64-R76): Updated the `test_wrong_new_password` method to reflect the stronger initial password.
* [`backend/unit_tests/endpoints/user/test_account.py`](diffhunk://#diff-a365bcac8188155330eba0d808fe1a9bb3f24d44683640bb6ef4c37ca004d090L64-R76): Added a new test method `test_same_password` to verify that the new password cannot be the same as the old password.

closes #79