### PR TITLE
Add password reset functionality with email notification and validation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,6 +20,7 @@ COPY test_system test_system
 COPY notifications notifications
 
 ENV SECRET_KEY="strong_secret_key"
+ENV PASSWORD_RESET_KEY="strong_password_reset_key"
 ENV PYTHONUNBUFFERED=1
 
 # Expose the port that the app runs on.

--- a/backend/endpoints/user/__init__.py
+++ b/backend/endpoints/user/__init__.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 from . import register
-from . import login, account
+from . import login, account, password_reset
 
 
 router = APIRouter()
 router.include_router(register.router)
 router.include_router(login.router)
 router.include_router(account.router)
+router.include_router(password_reset.router)

--- a/backend/endpoints/user/password_reset.py
+++ b/backend/endpoints/user/password_reset.py
@@ -1,0 +1,69 @@
+import os
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, EmailStr
+import jwt
+from sqlalchemy.orm import Session
+
+from database import get_db
+from database.models import User
+from .hashing import hash_password
+from .tools import is_strong_password, generate_token
+from endpoints.tools import MessageResponse, ErrorResponse
+from notifications.email import EmailNotificationService
+
+router = APIRouter()
+
+class PasswordResetRequest(BaseModel):
+    email: EmailStr
+
+@router.post("/request-password-reset", response_model=MessageResponse)
+async def request_password_reset(data: PasswordResetRequest, db: Session = Depends(get_db)):
+    """
+    Send email with link for password reset.
+    """
+    existing_user = db.query(User).filter(User.email == data.email).first()
+    if not existing_user:
+        return {"message": "A password reset link has been sent."}
+
+    token = generate_token(str(data.email), os.getenv("PASSWORD_RESET_KEY"))
+
+    front_end_url = os.getenv("FRONTEND_URL")
+
+    email_service = EmailNotificationService(existing_user)
+    email_service.send_notification("Password reset request",
+                                    f"To reset your password, click here: {front_end_url}/html/reset-password.html?token={token}")
+
+    return {"message": "A password reset link has been sent."}
+
+class ResetPassword(BaseModel):
+    password: str = Field(..., min_length=8, max_length=50)
+
+@router.post("/reset-password", response_model=MessageResponse, responses={
+    400: {"model": ErrorResponse, "description": "Bad Request (Token expired, Invalid token, Weak password)"},
+    404: {"model": ErrorResponse, "description": "Not Found (User not found)"}
+})
+async def reset_password(token: str, data: ResetPassword , db: Session = Depends(get_db)):
+    """
+    Resets the password for the user. The token is sent to the email.
+    """
+    secret_key = os.getenv("PASSWORD_RESET_KEY")
+
+    try:
+        payload = jwt.decode(token, secret_key, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=400, detail="Token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=400, detail="Invalid token")
+
+    user = db.query(User).filter(User.email == payload["email"]).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if not is_strong_password(data.password):
+        raise HTTPException(status_code=400, detail="Password is weak")
+
+    user.password_hash = hash_password(data.password)
+    db.commit()
+
+    return {"message": "Password reset successfully"}

--- a/backend/unit_tests/endpoints/user/test_password_reset.py
+++ b/backend/unit_tests/endpoints/user/test_password_reset.py
@@ -1,0 +1,112 @@
+import os
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from endpoints.user.hashing import hash_password, verify_password
+from endpoints.user.tools import generate_token
+from main import app
+from database.models import User, Base
+from database import get_db, engine, DatabaseSession
+from unit_tests.tools import clear_database
+
+
+class TestRequestPasswordReset:
+
+    @staticmethod
+    def setup_method():
+        clear_database()
+        db = next(get_db())
+        db.add(User(email="test@example.com", name="Test", surname="User", password_hash="hashed_password"))
+
+    @pytest.fixture
+    def client(self):
+        return TestClient(app)
+
+    def test_register_user_success(self, client):
+        with patch("endpoints.user.register.generate_token", return_value="token"):
+            response = client.post("/user/request-password-reset", json={
+                "email": "test@example.com"
+            })
+            assert response.status_code == 200
+            assert response.json() == {"message": "A password reset link has been sent."}
+
+    def test_not_existing_user(self, client):
+        with patch("endpoints.user.register.generate_token", return_value="token"):
+            response = client.post("/user/request-password-reset", json={
+                "email": "wrong@example.com"
+            })
+            assert response.status_code == 200
+            assert response.json() == {"message": "A password reset link has been sent."}
+
+
+class TestPasswordReset:
+
+    @pytest.fixture
+    def client(self):
+        return TestClient(app)
+
+    @staticmethod
+    def setup_method():
+        clear_database()
+        db = next(get_db())
+        db.add(User(email="test@example.com", name="Test", surname="User", password_hash=hash_password("old-password")))
+        db.commit()
+
+    def test_ok(self, client):
+
+        token = generate_token("test@example.com", os.getenv("PASSWORD_RESET_KEY"))
+
+        response = client.post(f"/user/reset-password?token={token}", json={
+            "password": "new-passwordA1!"
+        })
+
+        assert response.status_code == 200
+        assert response.json() == {"message": "Password reset successfully"}
+        db = next(get_db())
+        user = db.query(User).filter(User.email == "test@example.com").first()
+        assert verify_password("new-passwordA1!", user.password_hash)
+        assert not verify_password("old-password", user.password_hash)
+
+    def test_invalid_token(self, client):
+
+        response = client.post("/user/reset-password?token=invalid", json={
+            "password": "new-passwordA1!"
+        })
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Invalid token"}
+
+    def test_expired_token(self, client):
+
+        token = generate_token("test@example.com", secret_key=os.getenv("PASSWORD_RESET_KEY"),
+                               expiration_date=datetime.now(timezone.utc) - timedelta(minutes=5))
+
+        response = client.post(f"/user/reset-password?token={token}", json={
+            "password": "new-passwordA1!"
+        })
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Token expired"}
+
+    def test_invalid_email(self, client):
+        token = generate_token("invalid@example.com", secret_key=os.getenv("PASSWORD_RESET_KEY"))
+
+        response = client.post(f"/user/reset-password?token={token}", json={
+            "password": "new-passwordA1!"
+        })
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "User not found"}
+
+    def test_weak_password(self, client):
+        token = generate_token("test@example.com", secret_key=os.getenv("PASSWORD_RESET_KEY"))
+
+        response = client.post(f"/user/reset-password?token={token}", json={
+            "password": "weakpassword"
+        })
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Password is weak"}

--- a/backend/unit_tests/endpoints/user/test_register.py
+++ b/backend/unit_tests/endpoints/user/test_register.py
@@ -123,7 +123,6 @@ class TestConfirmEmail:
 
         response = client.get(f"/user/confirm_email?token={token}")
 
-        print(response.json())
         assert response.status_code == 200
         assert response.json() == {"message": "Email confirmed successfully"}
         db = next(get_db())


### PR DESCRIPTION
This pull request introduces a password reset feature to the backend system, including new endpoints, environment variables, and unit tests. The most important changes are as follows:

### Password Reset Feature:

* [`backend/endpoints/user/password_reset.py`](diffhunk://#diff-debe3ddf2637c9edb43eab0859779efab708e54a704947b6a1be011feb6d274aR1-R69): Added new endpoints for requesting a password reset and for resetting the password using a token. This includes validation and error handling for token expiration, invalid tokens, and weak passwords.
* [`backend/endpoints/user/__init__.py`](diffhunk://#diff-cd03f3869ed6caa09c2d90b094a5bbdd4dc8f2c300bbcb486b260293f06b20f0L3-R10): Included the newly created `password_reset` router in the user endpoints.
* [`backend/Dockerfile`](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486R23): Added a new environment variable `PASSWORD_RESET_KEY` for securing the password reset tokens.

### Unit Tests:

* [`backend/unit_tests/endpoints/user/test_password_reset.py`](diffhunk://#diff-3337c1baa26c80b18252b39629afc85d26c84ed54f4a9d184f7aea1e397cc174R1-R112): Added unit tests for the password reset feature, covering scenarios such as successful password reset, invalid token, expired token, invalid email, and weak password.

### Minor Cleanup:

* [`backend/unit_tests/endpoints/user/test_register.py`](diffhunk://#diff-52725c79f0bc7d78f9f8f66e463fc8f2268052a5c0707f7eedea187bbb453fe8L126): Removed a print statement from the `test_confirm_email_success` method to clean up the test output.

closes #50 