### PR TITLE
Modified endpoints path for question retrieval and answering

### DIFF
--- a/backend/endpoints/teaching/__init__.py
+++ b/backend/endpoints/teaching/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
-from . import random
+from . import random, test
 
 router = APIRouter()
 router.include_router(random.router, prefix="/random")
+router.include_router(test.router, prefix="/test")

--- a/backend/endpoints/teaching/random/words.py
+++ b/backend/endpoints/teaching/random/words.py
@@ -1,16 +1,10 @@
-import pickle
-from unicodedata import category
-
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
-from typing_extensions import Buffer
 
 from database.models import User
 from endpoints.user.tools import validate_session
 from endpoints.tools import MessageResponse, ErrorResponse
 from test_system.caching import RedisCaching, RedisCachingException as CachingException
 from test_system.random.words import WordTranslationsTestBuilder as TestBuilder
-from test_system.main import QuestionJsonBase, Test, Result, NoQuestionsException
 
 router = APIRouter()
 
@@ -23,37 +17,3 @@ async def init_test(user: User = Depends(validate_session)):
     except CachingException:
         raise HTTPException(status_code=400, detail="Test session is already initialized")
     return MessageResponse(message="Test session initialized")
-
-
-@router.get("/get_question", response_model=QuestionJsonBase | MessageResponse, responses={
-    400: {"model": ErrorResponse, "description": "Bad Request: Test session is not initialized"},
-    200: {"description": "Current question or message that test is finished"}
-})
-async def get_question(user: User = Depends(validate_session)):
-    try:
-        test = Test.load_from_cache(user, caching_class=RedisCaching)
-    except CachingException:
-        raise HTTPException(status_code=400, detail="Test session is not initialized")
-    question = test.get_question()
-    if question is None:
-        return MessageResponse(message="Test is finished")
-    return question
-
-
-class AnswerQuestion(BaseModel):
-    answer: str = Field(..., description="Answer to the question")
-
-
-@router.post("/answer_question", response_model=Result, responses={
-    400: {"model": ErrorResponse, "description": "Bad Request: Test session is not initialized"}
-})
-async def answer_question(data: AnswerQuestion, user: User = Depends(validate_session)):
-    try:
-        test = Test.load_from_cache(user, caching_class=RedisCaching)
-    except CachingException:
-        raise HTTPException(status_code=400, detail="Test session is not initialized")
-    try:
-        answer = test.give_answer(data.answer)
-    except NoQuestionsException:
-        raise HTTPException(status_code=400, detail="Test is finished")
-    return answer

--- a/backend/endpoints/teaching/test/__init__.py
+++ b/backend/endpoints/teaching/test/__init__.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from database.models import User
+from endpoints.tools import MessageResponse, ErrorResponse
+from endpoints.user.tools import validate_session
+from test_system.caching import RedisCaching, RedisCachingException as CachingException
+from test_system.main import QuestionJsonBase, Test, Result, NoQuestionsException
+
+
+router = APIRouter()
+
+
+@router.get("/get_question", response_model=QuestionJsonBase | MessageResponse, responses={
+    400: {"model": ErrorResponse, "description": "Bad Request: Test session is not initialized"},
+    200: {"description": "Current question or message that test is finished"}
+})
+async def get_question(user: User = Depends(validate_session)):
+    try:
+        test = Test.load_from_cache(user, caching_class=RedisCaching)
+    except CachingException:
+        raise HTTPException(status_code=400, detail="Test session is not initialized")
+    question = test.get_question()
+    if question is None:
+        return MessageResponse(message="Test is finished")
+    return question
+
+
+class AnswerQuestion(BaseModel):
+    answer: str = Field(..., description="Answer to the question")
+
+
+@router.post("/answer_question", response_model=Result, responses={
+    400: {"model": ErrorResponse, "description": "Bad Request: Test session is not initialized"}
+})
+async def answer_question(data: AnswerQuestion, user: User = Depends(validate_session)):
+    try:
+        test = Test.load_from_cache(user, caching_class=RedisCaching)
+    except CachingException:
+        raise HTTPException(status_code=400, detail="Test session is not initialized")
+    try:
+        answer = test.give_answer(data.answer)
+    except NoQuestionsException:
+        raise HTTPException(status_code=400, detail="Test is finished")
+    return answer

--- a/backend/unit_tests/endpoints/teaching/random/test_words.py
+++ b/backend/unit_tests/endpoints/teaching/random/test_words.py
@@ -52,18 +52,18 @@ class TestWordsTesting:
         assert result.status_code == 200
         assert result.json() == {"message": "Test session initialized"}
         for i in range(10):
-            result = client.get("/teaching/random/words/get_question")
+            result = client.get("/teaching/test/get_question")
             assert result.status_code == 200
             assert result.json().get("question", None) is not None
             logging.info("Got question: " + result.json().get("question"))
-            result = client.post("/teaching/random/words/answer_question",
+            result = client.post("/teaching/test/answer_question",
                                  json={"answer": self.word_translated.word})
             assert result.status_code == 200
             assert result.json().get("is_correct") is True
-        result = client.get("/teaching/random/words/get_question")
+        result = client.get("/teaching/test/get_question")
         assert result.status_code == 200
         assert result.json().get("message", None) is not None
-        result = client.post("/teaching/random/words/answer_question",
+        result = client.post("/teaching/test/answer_question",
                              json={"answer": self.word_translated.word})
         assert result.status_code == 400
         assert result.json() == {"detail": "Test session is not initialized"}
@@ -79,10 +79,10 @@ class TestWordsTesting:
         assert result.json() == {"detail": "Test session is already initialized"}
 
     def test_not_initialized(self, client):
-        result = client.get("/teaching/random/words/get_question")
+        result = client.get("/teaching/test/get_question")
         assert result.status_code == 400
         assert result.json() == {"detail": "Test session is not initialized"}
-        result = client.post("/teaching/random/words/answer_question",
+        result = client.post("/teaching/test/answer_question",
                              json={"answer": self.word_translated.word})
         assert result.status_code == 400
         assert result.json() == {"detail": "Test session is not initialized"}
@@ -92,11 +92,11 @@ class TestWordsTesting:
         assert result.status_code == 200
         assert result.json() == {"message": "Test session initialized"}
         for i in range(10):
-            result = client.post("/teaching/random/words/answer_question",
+            result = client.post("/teaching/test/answer_question",
                                  json={"answer": "wrong"})
             assert result.status_code == 200
             assert result.json().get("is_correct") is False
-        result = client.post("/teaching/random/words/answer_question",
+        result = client.post("/teaching/test/answer_question",
                              json={"answer": self.word_translated.word})
         assert result.status_code == 400
         assert result.json() == {"detail": "Test is finished"}


### PR DESCRIPTION
This pull request refactors the test-related endpoints by moving them from the `random` module to a new `test` module. This change involves updating imports, modifying endpoint routes, and adjusting the corresponding unit tests to reflect the new structure.

Refactoring test-related endpoints:

* [`backend/endpoints/teaching/__init__.py`](diffhunk://#diff-b16ca2030b6860bfac827a2959e197b68950d42d385293ae245ca229301daa25L2-R6): Added import for the `test` module and included its router with the prefix `/test`.
* [`backend/endpoints/teaching/random/words.py`](diffhunk://#diff-5d6d7e1034df5b372275a5976dc32a23c27b9c781840cb3ed142e4c78c709897L1-L13): Removed the `get_question` and `answer_question` endpoints, and cleaned up unused imports. [[1]](diffhunk://#diff-5d6d7e1034df5b372275a5976dc32a23c27b9c781840cb3ed142e4c78c709897L1-L13) [[2]](diffhunk://#diff-5d6d7e1034df5b372275a5976dc32a23c27b9c781840cb3ed142e4c78c709897L26-L59)
* [`backend/endpoints/teaching/test/__init__.py`](diffhunk://#diff-18658dc3d3ed2eb7f7063162c304f9f0f397f9accca680d6fd8af3913a54ac27R1-R45): Added the `get_question` and `answer_question` endpoints, along with the necessary imports and dependencies.

Updating unit tests:

* [`backend/unit_tests/endpoints/teaching/random/test_words.py`](diffhunk://#diff-9fd0621227fb1af693c01881d6f57b92a3463bd7ff4926ae7753dc6a2af9a73dL55-R66): Updated the endpoint paths in the test methods to use the new `test` module routes. [[1]](diffhunk://#diff-9fd0621227fb1af693c01881d6f57b92a3463bd7ff4926ae7753dc6a2af9a73dL55-R66) [[2]](diffhunk://#diff-9fd0621227fb1af693c01881d6f57b92a3463bd7ff4926ae7753dc6a2af9a73dL82-R85) [[3]](diffhunk://#diff-9fd0621227fb1af693c01881d6f57b92a3463bd7ff4926ae7753dc6a2af9a73dL95-R99)