### PR TITLE
Refactor NewWordsTestBuilder to TestBuilder

### DIFF
--- a/backend/endpoints/teaching/tests/words.py
+++ b/backend/endpoints/teaching/tests/words.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from database.models import User
 from endpoints.tools import MessageResponse, ErrorResponse
 from endpoints.user.tools import validate_session
-from test_system.builder.test import NewWordsTestBuilder
+from test_system.builder.test import TestBuilder
 from test_system.caching import RedisCaching, RedisCachingException as CachingException
 
 router = APIRouter()
@@ -13,7 +13,9 @@ router = APIRouter()
 })
 async def init_test_new_words(user: User = Depends(validate_session)):
     try:
-        NewWordsTestBuilder.build(user, caching_class=RedisCaching)
+        builder = TestBuilder(user)
+        builder.add_new_words(10)
+        builder.build(caching_class=RedisCaching)
     except CachingException:
         raise HTTPException(status_code=400, detail="Test session is already initialized")
     return MessageResponse(message="Test session initialized")

--- a/backend/test_system/builder/test.py
+++ b/backend/test_system/builder/test.py
@@ -9,17 +9,21 @@ from test_system.builder.question import get_new_translations, build_msq_questio
 from test_system.words import TranslationKnowledgeSaver, TranslationQuestion
 
 
-class NewWordsTestBuilder:
-    @staticmethod
-    def build(user: User, number: int = 10, caching_class: Type[CachingInterface] | None = None) -> Test:
-        questions = []
+class TestBuilder:
+    def __init__(self, user: User):
+        self.__questions = []
+        self.__user = user
+
+    def add_new_words(self, number: int = 10) -> None:
         translations = get_new_translations(number, 10)
         for translation in translations:
             if randint(0, 1) == 0:
                 question = build_msq_question(translation)
             else:
                 question = TranslationQuestion(translation)
-            question = QuestionProxy(question, TranslationKnowledgeSaver(user, translation))
-            questions.append(question)
-        test = Test(user, questions, caching_class)
+            question = QuestionProxy(question, TranslationKnowledgeSaver(self.__user, translation))
+            self.__questions.append(question)
+
+    def build(self, caching_class: Type[CachingInterface] | None = None) -> Test:
+        test = Test(self.__user, self.__questions, caching_class)
         return test


### PR DESCRIPTION
This pull request refactors the test-building logic in the `teaching/tests/words.py` endpoint by replacing the static `NewWordsTestBuilder` class with a more flexible `TestBuilder` class. The changes improve code maintainability and allow for easier extension of test-building functionality.

### Refactoring of test-building logic:

* **Replaced `NewWordsTestBuilder` with `TestBuilder`**: The `TestBuilder` class introduces an object-oriented approach, encapsulating user and question data. It includes methods like `add_new_words` for adding questions and `build` for constructing a test. This replaces the static `NewWordsTestBuilder.build` method. (`backend/test_system/builder/test.py`, [backend/test_system/builder/test.pyL12-R28](diffhunk://#diff-344ec893c36e72d4fbeb7b582cdf3e8579154d4ed0a9cd29599d317579f6cd5bL12-R28))

* **Updated `init_test_new_words` function to use `TestBuilder`**: The function now initializes a `TestBuilder` instance, adds new word questions, and builds the test using the new class. This aligns the endpoint logic with the refactored builder class. (`backend/endpoints/teaching/tests/words.py`, [backend/endpoints/teaching/tests/words.pyL16-R18](diffhunk://#diff-f439a59d3dfacf934afc715ac35264ce17c52a02db8349888c702bfc68dcc6f9L16-R18))

* **Modified import statements**: Adjusted imports in `teaching/tests/words.py` to reflect the renaming of `NewWordsTestBuilder` to `TestBuilder`. (`backend/endpoints/teaching/tests/words.py`, [backend/endpoints/teaching/tests/words.pyL6-R6](diffhunk://#diff-f439a59d3dfacf934afc715ac35264ce17c52a02db8349888c702bfc68dcc6f9L6-R6))