### PR TITLE
Add function and endpoint to initialize test sessions with strong knowledge sentences.

### DIFF
--- a/backend/endpoints/teaching/tests/sentences.py
+++ b/backend/endpoints/teaching/tests/sentences.py
@@ -33,3 +33,16 @@ async def init_test_weak_sentences(user: User = Depends(validate_session)):
     except CachingException:
         raise HTTPException(status_code=400, detail="Test session is already initialized")
     return MessageResponse(message="Test session initialized")
+
+@router.post("/strong-knowledge", response_model=MessageResponse, responses={
+    400: {"model": ErrorResponse, "description": "Bad Request: Test session is already initialized"}
+})
+async def init_test_weak_sentences(user: User = Depends(validate_session)):
+    """Initialize a test session with sentences with strong knowledge."""
+    try:
+        builder = TestBuilder(user)
+        builder.add_strong_knowledge_sentences()
+        builder.build(caching_class=RedisCaching)
+    except CachingException:
+        raise HTTPException(status_code=400, detail="Test session is already initialized")
+    return MessageResponse(message="Test session initialized")

--- a/backend/test_system/builder/question.py
+++ b/backend/test_system/builder/question.py
@@ -140,3 +140,22 @@ def get_sentence_translations_weak_knowledge(number: int = 10, min_knowledge: in
         translations.append(translation)
 
     return translations
+
+def get_sentence_translations_strong_knowledge(number: int = 10, min_knowledge: int = 70) -> List[SentenceTranslation]:
+    db = next(get_db())
+    translations = []
+
+    translations_db = db.query(SentenceTranslation, SentenceTranslationKnowledge) \
+        .join(SentenceTranslationKnowledge, SentenceTranslationKnowledge.sentence_translation_id == SentenceTranslation.id, isouter=True) \
+        .filter(SentenceTranslationKnowledge.knowledge >= min_knowledge) \
+        .order_by(func.random()) \
+        .limit(number).all()
+
+    for translation, knowledge in translations_db:
+        db.refresh(translation)
+        db.refresh(translation.sentence_original)
+        db.refresh(translation.sentence_translated)
+        db.expunge(translation)
+        translations.append(translation)
+
+    return translations

--- a/backend/test_system/builder/test.py
+++ b/backend/test_system/builder/test.py
@@ -5,8 +5,10 @@ from typing import Type
 from database.models import User
 from test_system.caching import CachingInterface
 from test_system.main import Test, QuestionProxy
-from test_system.builder.question import get_new_word_translations, build_msq_question, get_word_translations_weak_knowledge, \
-    get_word_translations_strong_knowledge, get_new_sentence_translations, get_sentence_translations_weak_knowledge
+from test_system.builder.question import get_new_word_translations, build_msq_question, \
+    get_word_translations_weak_knowledge, \
+    get_word_translations_strong_knowledge, get_new_sentence_translations, \
+    get_sentence_translations_weak_knowledge, get_sentence_translations_strong_knowledge
 from test_system.words import TranslationKnowledgeSaver, TranslationQuestion
 import test_system.sentences as sentences
 
@@ -58,6 +60,16 @@ class TestBuilder:
 
     def add_weak_sentences(self, number: int = 10) -> None:
         translations = get_sentence_translations_weak_knowledge(number)
+        for translation in translations:
+            if randint(0, 1) == 0:
+                question = sentences.ReorderTranslationQuestion(translation)
+            else:
+                question = sentences.TranslationQuestion(translation)
+            question = QuestionProxy(question, sentences.TranslationKnowledgeSaver(self.__user, translation))
+            self.__questions.append(question)
+
+    def add_strong_knowledge_sentences(self, number: int = 10) -> None:
+        translations = get_sentence_translations_strong_knowledge(number)
         for translation in translations:
             if randint(0, 1) == 0:
                 question = sentences.ReorderTranslationQuestion(translation)


### PR DESCRIPTION
This pull request introduces functionality to support initializing test sessions with sentences that demonstrate strong knowledge, alongside the existing weak knowledge functionality. Key changes include adding a new endpoint, implementing a method to retrieve sentence translations with strong knowledge, and integrating this functionality into the test-building process.

### New functionality for strong knowledge sentences:

* **New API endpoint:** Added the `init_test_weak_sentences` endpoint to initialize test sessions with sentences demonstrating strong knowledge. This includes error handling for already initialized sessions. (`backend/endpoints/teaching/tests/sentences.py`, [backend/endpoints/teaching/tests/sentences.pyR36-R48](diffhunk://#diff-95e4c1a2df4af24656d4abb2f7d1757f95338f85bfa672089b07110bcb51d651R36-R48))

* **Database query for strong knowledge sentences:** Implemented the `get_sentence_translations_strong_knowledge` function to retrieve sentence translations with a minimum knowledge threshold, using a random order and limiting the number of results. (`backend/test_system/builder/question.py`, [backend/test_system/builder/question.pyR143-R161](diffhunk://#diff-080ebdf70f504a92fa9b595b8bb9b7001e1264064a7b142261bed7883ecd0132R143-R161))

### Integration into test-building process:

* **Test builder enhancement:** Added the `add_strong_knowledge_sentences` method in the `TestBuilder` class to generate questions from strong knowledge sentences. This method creates either `ReorderTranslationQuestion` or `TranslationQuestion` objects based on random selection. (`backend/test_system/builder/test.py`, [backend/test_system/builder/test.pyR71-R80](diffhunk://#diff-344ec893c36e72d4fbeb7b582cdf3e8579154d4ed0a9cd29599d317579f6cd5bR71-R80))

* **Import updates:** Updated imports in `test.py` to include the new `get_sentence_translations_strong_knowledge` function. (`backend/test_system/builder/test.py`, [backend/test_system/builder/test.pyL8-R11](diffhunk://#diff-344ec893c36e72d4fbeb7b582cdf3e8579154d4ed0a9cd29599d317579f6cd5bL8-R11))