### PR TITLE
Fix option generation to append modified word instead of original

### DIFF
--- a/backend/test_system/builder/question.py
+++ b/backend/test_system/builder/question.py
@@ -40,7 +40,7 @@ def build_msq_question(translation: WordTranslation) -> MSQQuestion:
     word = str(right_word)
     word = change_word(word)
     if word != right_word:
-        options.append(right_word)
+        options.append(word)
 
     question = MSQQuestion(translation, options)
     return question


### PR DESCRIPTION
This pull request includes a minor fix in the `backend/test_system/builder/question.py` file. The change ensures that the correct variable (`word`) is appended to the `options` list instead of the original `right_word`.

* [`backend/test_system/builder/question.py`](diffhunk://#diff-080ebdf70f504a92fa9b595b8bb9b7001e1264064a7b142261bed7883ecd0132L43-R43): Updated the `change_word` function to append the modified `word` variable to the `options` list, ensuring consistency with the logic of the function.

closes #119 