### PR TITLE
Fix typo in function name

### DIFF
--- a/backend/endpoints/teaching/tests/sentences.py
+++ b/backend/endpoints/teaching/tests/sentences.py
@@ -37,7 +37,7 @@ async def init_test_weak_sentences(user: User = Depends(validate_session)):
 @router.post("/strong-knowledge", response_model=MessageResponse, responses={
     400: {"model": ErrorResponse, "description": "Bad Request: Test session is already initialized"}
 })
-async def init_test_weak_sentences(user: User = Depends(validate_session)):
+async def init_test_strong_sentences(user: User = Depends(validate_session)):
     """Initialize a test session with sentences with strong knowledge."""
     try:
         builder = TestBuilder(user)


### PR DESCRIPTION
This pull request includes a small but important change to the `backend/endpoints/teaching/tests/sentences.py` file. The function name was updated to better reflect its purpose.

* The function `init_test_weak_sentences` was renamed to `init_test_strong_sentences` to align with the endpoint's purpose of initializing a test session with sentences indicating strong knowledge. (`[backend/endpoints/teaching/tests/sentences.pyL40-R40](diffhunk://#diff-95e4c1a2df4af24656d4abb2f7d1757f95338f85bfa672089b07110bcb51d651L40-R40)`)

closes #121