### PR TITLE
Fix token expiration date handling in generate_token function

### DIFF
--- a/backend/endpoints/user/tools.py
+++ b/backend/endpoints/user/tools.py
@@ -27,7 +27,9 @@ def is_strong_password(password: str) -> bool:
 
 def generate_token(email: str,
                          secret_key: str,
-                         expiration_date: datetime = datetime.now(timezone.utc) + timedelta(minutes=5)) -> str:
+                         expiration_date: datetime | None = None) -> str:
+    if expiration_date is None:
+        expiration_date = datetime.now(timezone.utc) + timedelta(minutes=5)
     token = jwt.encode({"email": email, "exp": expiration_date},
                           secret_key, algorithm="HS256")
     return token


### PR DESCRIPTION
This pull request modifies the `generate_token` function in `backend/endpoints/user/tools.py` to improve flexibility and handle default expiration dates more robustly.

### Key Change:
* Updated the `generate_token` function to accept an optional `expiration_date` parameter. If no value is provided, the function now calculates a default expiration date of 5 minutes from the current time. This change enhances flexibility by allowing callers to specify custom expiration dates while maintaining a sensible default.

closes #118 